### PR TITLE
added savvy app key

### DIFF
--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/analytics/internal/BMSAnalytics.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/analytics/internal/BMSAnalytics.java
@@ -68,6 +68,7 @@ public class BMSAnalytics {
 
     protected static String clientApiKey = null;
     protected static String appName = null;
+    protected static String savvyAppKey = null;
     public static boolean isRecordingNetworkEvents = false;
 
     protected static String HASHED_DEFAULT_USER_ID;
@@ -129,6 +130,10 @@ public class BMSAnalytics {
 
         //Intercept requests to add device metadata header
         BaseRequest.registerInterceptor(new MetadataHeaderInterceptor(context.getApplicationContext()));
+    }
+
+    public static void initSavvy(String appKey) {
+        BMSAnalytics.savvyAppKey = appKey;
     }
 
     static protected String getDeviceID(Context context) {
@@ -254,6 +259,10 @@ public class BMSAnalytics {
 
     public static String getAppName(){
         return appName;
+    }
+
+    public static String getSavvyAppKey() {
+        return savvyAppKey;
     }
 
     /**

--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/analytics/internal/BMSAnalytics.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/analytics/internal/BMSAnalytics.java
@@ -132,6 +132,11 @@ public class BMSAnalytics {
         BaseRequest.registerInterceptor(new MetadataHeaderInterceptor(context.getApplicationContext()));
     }
 
+    /**
+     * Initialize Savvy API if it is being used. This must be called before interaction data can be sent
+     *
+     * @param appKey The key provided the the application developer from the Savvy Dashboard
+     */
     public static void initSavvy(String appKey) {
         BMSAnalytics.savvyAppKey = appKey;
     }

--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/logger/api/LogPersister.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/logger/api/LogPersister.java
@@ -977,7 +977,7 @@ public final class LogPersister {
 
                     if (fileName.equals(USER_INTERACTIONS_FILENAME)) {
                         fileData = "[" + fileData.substring(0, fileData.length() - 1) + "]";
-                        logDataKey = "log";
+                        logDataKey = "events";
                         JSONArray logArray = new JSONArray(fileData);
                         payloadObj.put(logDataKey, logArray);
                     } else {

--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/logger/internal/InteractionRequestUtil.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/logger/internal/InteractionRequestUtil.java
@@ -36,7 +36,7 @@ public class InteractionRequestUtil {
             PackageInfo info = packageManager.getPackageInfo(context.getPackageName(), 0);
             payload.put("appVersion", info.versionName);
             payload.put("appVersionCode", Integer.toString(info.versionCode));
-            payload.put("appID", BMSAnalytics.getSavvyAppKey());
+            payload.put("appKey", BMSAnalytics.getSavvyAppKey());
 
             Resources resources = context.getResources();
 

--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/logger/internal/InteractionRequestUtil.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/logger/internal/InteractionRequestUtil.java
@@ -22,7 +22,15 @@ public class InteractionRequestUtil {
 
     }
 
-    public static JSONObject getInteractionRequestPayload(JSONObject payload, final Context context) {
+    /**
+     * Adds the fields that each interaction event will need but is not unique to the event. This
+     * reduces the size of the request being made since this data is not duplicated for each event
+     *
+     * @param payload The current payload of the request
+     * @param context A context to provide access to package information
+     * @return The payload with the required fields added
+     */
+    public static JSONObject getInteractionRequestPayload(JSONObject payload, Context context) {
         BaseDeviceIdentity deviceIdentity = new BaseDeviceIdentity(context);
 
         try {

--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/logger/internal/InteractionRequestUtil.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/logger/internal/InteractionRequestUtil.java
@@ -8,6 +8,7 @@ import android.content.res.Resources;
 import android.util.DisplayMetrics;
 import android.util.Log;
 
+import com.ibm.mobilefirstplatform.clientsdk.android.analytics.internal.BMSAnalytics;
 import com.ibm.mobilefirstplatform.clientsdk.android.security.identity.BaseDeviceIdentity;
 
 import org.json.JSONException;
@@ -35,7 +36,7 @@ public class InteractionRequestUtil {
             PackageInfo info = packageManager.getPackageInfo(context.getPackageName(), 0);
             payload.put("appVersion", info.versionName);
             payload.put("appVersionCode", Integer.toString(info.versionCode));
-            payload.put("appID", context.getPackageName());
+            payload.put("appID", BMSAnalytics.getSavvyAppKey());
 
             Resources resources = context.getResources();
 


### PR DESCRIPTION
Adds the savvy app key for sending interaction data.

To test:

- run the savvy server with the new changes for app key
- pull from 49_addAppKey (savvy-android-sdk)
- run ./dependencies
- run the TouchPoint application
- interact with the app and wait two minutes
- check database for correct appKey